### PR TITLE
improve "hide scrollbar hack"

### DIFF
--- a/library/Denkmal/layout/default/Page/Events/default.less
+++ b/library/Denkmal/layout/default/Page/Events/default.less
@@ -132,9 +132,9 @@
       position: absolute;
       left: 0;
       top: 0;
-      right: -15px;
+      right: -20px;
       height: 100%;
-      padding-right: 15px; // hide scrollbar hack
+      padding-right: 20px; // hide scrollbar hack
       overflow-y: scroll;
     }
   }


### PR DESCRIPTION
_15px_ seems to be not enough to hide the scrollbar in IE9
![screen shot 2014-04-12 at 21 37 21](https://cloud.githubusercontent.com/assets/1888817/2687959/f5d344d0-c279-11e3-957e-41c3e2cb4811.png)
