### PR TITLE
Event page: Render weekday non-bold?

### DIFF
--- a/library/Denkmal/layout/default/Component/EventList/default.less
+++ b/library/Denkmal/layout/default/Component/EventList/default.less
@@ -7,7 +7,6 @@
 }
 
 .weekday {
-  font-weight: bold;
   margin-right: 5px;
 }
 


### PR DESCRIPTION
Because the weekday is already highly visible in the navigation?
As reported by @NicolasSchmutz 

![screen shot 2014-04-22 at 23 15 08](https://cloud.githubusercontent.com/assets/360800/2770827/3e6feff4-ca63-11e3-8654-ae33ee8b4024.png)

![selfie-0](http://i.imgur.com/A2vt2N5.png)
