### PR TITLE
sort starred upcoming events for "venue-view" correct

### DIFF
--- a/library/Denkmal/library/Denkmal/Paging/Event/VenueFuture.php
+++ b/library/Denkmal/library/Denkmal/Paging/Event/VenueFuture.php
@@ -17,7 +17,7 @@ class Denkmal_Paging_Event_VenueFuture extends Denkmal_Paging_Event_Abstract {
             $where .= ' AND `enabled` = 1 AND `hidden` = 0';
         }
 
-        $source = new CM_PagingSource_Sql('id', 'denkmal_model_event', $where, '`starred` DESC, `from`');
+        $source = new CM_PagingSource_Sql('id', 'denkmal_model_event', $where, '`from`');
         parent::__construct($source);
     }
 }


### PR DESCRIPTION
Starred events in the "venue view" should also be sorted by date. Currently they show up on top.

![screen shot 2014-09-22 at 16 47 45](https://cloud.githubusercontent.com/assets/4020326/4358125/bf465eca-4267-11e4-965c-86390aaae2cb.png)
