### PR TITLE
EventDetails: noContent and map should be on same height

### DIFF
--- a/library/Denkmal/layout/default/Component/EventDetails/default.less
+++ b/library/Denkmal/layout/default/Component/EventDetails/default.less
@@ -60,6 +60,6 @@
 .noContent {
   overflow: hidden;
   border: 2px dashed @colorFgBorderEmphasize3;
-  margin: 5px;
+  margin: 20px 5px 5px;
   color: @colorFgSubtle;
 }


### PR DESCRIPTION
![screen shot 2014-04-19 at 17 42 53](https://cloud.githubusercontent.com/assets/360800/2748831/5ae8a7ac-c7d9-11e3-9094-7312bf54d8bb.png)
