### PR TITLE
Enable "remember me" in session for 14d

### DIFF
--- a/library/Denkmal/library/Denkmal/FormAction/Login/Process.php
+++ b/library/Denkmal/library/Denkmal/FormAction/Login/Process.php
@@ -21,6 +21,8 @@ class Denkmal_FormAction_Login_Process extends CM_FormAction_Abstract {
         }
 
         $response->getRequest()->getSession()->setUser($user);
+        $response->getRequest()->getSession()->setLifetime(86400 * 14);
+
         $response->addMessage($response->getRender()->getTranslation('Erfolgreich angemeldet. Bitte warten...'));
         $response->redirect($site->getLoginPage(), null, true);
     }


### PR DESCRIPTION
@vanillafudge @nicolasschmutz @christopheschwyzer @kris-lab 

I'm enabling a "remember me" for the login in the user's session for 14 days.
There's no checkbox, so the user needs to remember to log out again if he's using a shared computer.
This will also affect the admin.

I think it's reasonable afterall, wdyt?