### PR TITLE
Chat: venue name should link to event information?

### DIFF
--- a/library/Denkmal/layout/default/Page/Now/default.less
+++ b/library/Denkmal/layout/default/Page/Now/default.less
@@ -27,6 +27,14 @@
   }
 }
 
+.Denkmal_Component_Event {
+  padding: 8px 8px 0;
+
+  .contextButton {
+    display: none;
+  }
+}
+
 .Denkmal_Component_MessageList_Abstract {
   padding: 15px 12px;
 

--- a/library/Denkmal/layout/default/Page/Now/default.tpl
+++ b/library/Denkmal/layout/default/Page/Now/default.tpl
@@ -15,6 +15,9 @@
         {$venue->getName()|escape}
       </a>
     </div>
+    {if isset($event)}
+      {component name='Denkmal_Component_Event' event=$event}
+    {/if}
   {/if}
 
   {if $venue}

--- a/library/Denkmal/library/Denkmal/Page/Now.php
+++ b/library/Denkmal/library/Denkmal/Page/Now.php
@@ -12,6 +12,13 @@ class Denkmal_Page_Now extends Denkmal_Page_Abstract {
             $allowAdd = false;
         }
 
+        if ($venue) {
+            $currentDate = Denkmal_Site::getCurrentDate();
+            $eventList = new Denkmal_Paging_Event_VenueDate($currentDate, $venue);
+            $event = $eventList->getItem(0);
+            $viewResponse->set('event', $event);
+        }
+
         $viewResponse->set('venue', $venue);
         $viewResponse->getJs()->setProperty('venue', $venue);
         $viewResponse->set('allowAdd', $allowAdd);


### PR DESCRIPTION
As suggested by @vanillafudge:
When browsing messages on the chat page it might be nice if one could click on a venue name to get information about the event currently happening there.

Not sure how to do it best, ideas:
- Deep-link to the event on the calendar view (navigate to specific date, scroll down to event)
- Show information inline (similar to on event page, would expand event details below message).

I'm not convinced of either solution because of the additional complexity and noise they add. IMO we can omit this feature (at least for the time being).

@vanillafudge @christopheschwyzer @NicolasSchmutz @kris-lab  thoughts?