### PR TITLE
Broken weekday indication for outside current week

### DIFF
--- a/library/Denkmal/library/Denkmal/Page/Events.js
+++ b/library/Denkmal/library/Denkmal/Page/Events.js
@@ -7,6 +7,9 @@ var Denkmal_Page_Events = Denkmal_Page_Abstract.extend({
   /** @type String */
   _class: 'Denkmal_Page_Events',
 
+  /** @type String */
+  dateCurrent: null,
+
   /** @type SwipeCarousel */
   _carousel: null,
 
@@ -98,7 +101,7 @@ var Denkmal_Page_Events = Denkmal_Page_Abstract.extend({
   _changeState: function(state) {
     var date = state['date'];
     if (!date) {
-      date = this.$('.dateList > .date:first').data('date');
+      date = this.dateCurrent;
       this.setState({date: date});
     }
     return this.showPane(date);

--- a/library/Denkmal/library/Denkmal/Page/Events.php
+++ b/library/Denkmal/library/Denkmal/Page/Events.php
@@ -3,7 +3,8 @@
 class Denkmal_Page_Events extends Denkmal_Page_Abstract {
 
     public function prepare(CM_Frontend_Environment $environment, CM_Frontend_ViewResponse $viewResponse) {
-        $date = $this->_params->getDate('date', Denkmal_Site::getCurrentDate());
+        $dateCurrent = Denkmal_Site::getCurrentDate();
+        $date = $this->_params->getDate('date', $dateCurrent);
         $dateList = new Denkmal_Paging_DateTime_Days();
 
         if (in_array($date, $dateList->getItems())) {
@@ -17,5 +18,6 @@ class Denkmal_Page_Events extends Denkmal_Page_Abstract {
         }
         $viewResponse->set('menu', $menu);
         $viewResponse->set('date', $date);
+        $viewResponse->getJs()->setProperty('dateCurrent', $dateCurrent->format('Y-n-j'));
     }
 }


### PR DESCRIPTION
As reported by @christopheschwyzer 
When navigating to a calendar date view from outside the current week, then the weekday indication is empty (mobile).

E.g. this link: https://www.denkmal.org/events?date=2015-1-1
Will render like this:
![screen shot 2015-05-03 at 15 20 08](https://cloud.githubusercontent.com/assets/360800/7445182/0f80f86a-f1a8-11e4-9c74-d7ee2cad1722.png)
