### PR TITLE
Remove html entities from the event description

### DIFF
--- a/library/Denkmal/library/Denkmal/Model/Event.php
+++ b/library/Denkmal/library/Denkmal/Model/Event.php
@@ -173,7 +173,7 @@ class Denkmal_Model_Event extends CM_Model_Abstract implements Denkmal_ArrayConv
         $array = array();
         $array['id'] = $this->getId();
         $array['venue'] = $this->getVenue()->getId();
-        $array['description'] = strip_tags($descriptionHtml);
+        $array['description'] = html_entity_decode(strip_tags($descriptionHtml), ENT_QUOTES);
         $array['descriptionHtml'] = $descriptionHtml;
         $array['from'] = $this->getFrom()->getTimestamp();
         if ($until = $this->getUntil()) {

--- a/library/Denkmal/library/Denkmal/Model/Event.php
+++ b/library/Denkmal/library/Denkmal/Model/Event.php
@@ -173,7 +173,7 @@ class Denkmal_Model_Event extends CM_Model_Abstract implements Denkmal_ArrayConv
         $array = array();
         $array['id'] = $this->getId();
         $array['venue'] = $this->getVenue()->getId();
-        $array['description'] = html_entity_decode(strip_tags($descriptionHtml), ENT_QUOTES);
+        $array['description'] = html_entity_decode(strip_tags($descriptionHtml), ENT_QUOTES, 'UTF-8');
         $array['descriptionHtml'] = $descriptionHtml;
         $array['from'] = $this->getFrom()->getTimestamp();
         if ($until = $this->getUntil()) {


### PR DESCRIPTION
The description can contain single quote characters, represented as \&# 039;
The event's description should be clean from all html characters