### PR TITLE
Don't check mozilla webpush URL for version

### DIFF
--- a/library/Denkmal/library/Denkmal/Push/Notification/Provider/Abstract.php
+++ b/library/Denkmal/library/Denkmal/Push/Notification/Provider/Abstract.php
@@ -40,7 +40,7 @@ abstract class Denkmal_Push_Notification_Provider_Abstract implements CM_Service
         if (0 === strpos($endpoint, 'https://android.googleapis.com/gcm/send')) {
             return new Denkmal_Push_Notification_Provider_GoogleCloudMessaging($serviceManager);
         }
-        if (0 === strpos($endpoint, 'https://updates.push.services.mozilla.com/push/v1')) {
+        if (0 === strpos($endpoint, 'https://updates.push.services.mozilla.com/push')) {
             return new Denkmal_Push_Notification_Provider_WebPush($serviceManager);
         }
         return null;


### PR DESCRIPTION
Some Firefoxes don't have it?
E.g. "Mozilla/5.0 (Windows NT 10.0; WOW64; rv:45.0) Gecko/20100101 Firefox/45.0"