### PR TITLE
HeaderBar weekday vanishes in some navigation scenarios

### DIFF
--- a/library/Denkmal/library/Denkmal/Component/HeaderBar.js
+++ b/library/Denkmal/library/Denkmal/Component/HeaderBar.js
@@ -55,12 +55,13 @@ var Denkmal_Component_HeaderBar = Denkmal_Component_Abstract.extend({
    * @param {Boolean} state
    */
   setWeekdayMenuVisible: function(state) {
+    var callback = function(state) {
+      $(this).toggleClass('state-weekdayMenu', state);
+    };
     if (state) {
-      this.$el.toggleModal(function(state) {
-        $(this).toggleClass('state-weekdayMenu', state);
-      });
+      this.$el.toggleModal('open', callback);
     } else {
-      this.$el.toggleModal('close');
+      this.$el.toggleModal('close', callback);
     }
   },
 


### PR DESCRIPTION
@christopheschwyzer 

Reproduce in "mobile" view:
1. Open https://www.denkmal.org/events
2. Navigate to /now (with a click in headerbar)
3. Navigate back to /events (with a click in headerbar)
4. Click on the weekday in the headerbar. -> Weekday menu doesn't open
5. Click again on the weekday -> Headbar is `display:none`

