### PR TITLE
Admin content header pills menu "active" indication not visible

### DIFF
--- a/library/Admin/layout/default/Page/Abstract/default.less
+++ b/library/Admin/layout/default/Page/Abstract/default.less
@@ -1,9 +1,0 @@
-.content-header {
-  .clearfix;
-
-  .menu {
-    .label {
-      color: @colorFg;
-    }
-  }
-}


### PR DESCRIPTION
`.Admin_Page_Abstract .content-header .menu .label` makes it black. "Warnings" should be green:
<img width="430" alt="screen shot 2016-05-21 at 22 04 22" src="https://cloud.githubusercontent.com/assets/360800/15450604/2865f1a6-1fa0-11e6-8fc5-62308fc879e2.png">
