### PR TITLE
weekMenu not responding

### DIFF
--- a/library/Denkmal/layout/default/Component/HeaderBar/default.less
+++ b/library/Denkmal/layout/default/Component/HeaderBar/default.less
@@ -81,7 +81,7 @@
   }
 }
 
-&[data-weekdayWide=true] {
+&[data-weekday-wide] {
   .weekMenu {
     .menu.dates {
       width: auto;
@@ -97,7 +97,7 @@
   }
 }
 
-&[data-weekdayMenu=true] {
+&[data-weekday-menu] {
   .logo, .menu.main {
     display: none;
   }
@@ -139,7 +139,7 @@
   }
 }
 
-&[data-navigationIndication=false] {
+&:not([data-navigation-indication]) {
   .menu > li.active::after {
     display: none;
   }

--- a/library/Denkmal/library/Denkmal/Component/HeaderBar.js
+++ b/library/Denkmal/library/Denkmal/Component/HeaderBar.js
@@ -13,7 +13,7 @@ var Denkmal_Component_HeaderBar = Denkmal_Component_Abstract.extend({
   events: {
     'click .menu.dates a': function() {
       if (!this._weekdayWide) {
-        var state = !this.$el.attr('data-weekdayMenu');
+        var state = !this.el.hasAttribute('data-weekday-menu');
         this.setWeekdayMenuVisible(state);
       }
     }
@@ -55,7 +55,7 @@ var Denkmal_Component_HeaderBar = Denkmal_Component_Abstract.extend({
    */
   setWeekdayMenuVisible: function(state) {
     var callback = function(state) {
-      $(this).attr('data-weekdayMenu', state);
+      $(this).attr('data-weekday-menu', state ? '' : null);
     };
     if (state) {
       this.$el.toggleModal('open', callback);
@@ -69,7 +69,7 @@ var Denkmal_Component_HeaderBar = Denkmal_Component_Abstract.extend({
    */
   setWeekdayWide: function(state) {
     this._weekdayWide = state;
-    this.$el.attr('data-weekdayWide', state);
+    this.$el.attr('data-weekday-wide', state ? '' : null);
 
     if (false == state) {
       this.setWeekdayMenuVisible(false);
@@ -80,6 +80,6 @@ var Denkmal_Component_HeaderBar = Denkmal_Component_Abstract.extend({
    * @param {Boolean} state
    */
   setNavigationIndicationVisible: function(state) {
-    this.$el.attr('data-navigationIndication', state);
+    this.$el.attr('data-navigation-indication', state ? '' : null);
   }
 });


### PR DESCRIPTION
As reported by Gianna:
On mobile click on the week day in the header and select another day. Afterwards the `weekMenu` does not respond anymore.