### PR TITLE
Night-mode animation broke in FF

### DIFF
--- a/library/Denkmal/layout/default/Component/HeaderBar/default.less
+++ b/library/Denkmal/layout/default/Component/HeaderBar/default.less
@@ -194,12 +194,15 @@
 
     #eyebrow-left,
     #eyebrow-right {
+      transform-origin: center;
       transform: translateY(-30%);
+      transform-box: fill-box;
     }
 
     #eyelid-left,
     #eyelid-right {
       transform: translateY(100%);
+      transform-box: fill-box;
     }
   }
 }
@@ -208,14 +211,17 @@
   #logo-icon-night {
     #eyes {
       animation: eyes 60s linear 2s infinite;
+      transform-box: fill-box;
     }
 
     #eyebrow-left {
       animation: eyebrow-left 60s linear 2s infinite;
+      transform-box: fill-box;
     }
 
     #eyebrow-right {
       animation: eyebrow-right 60s linear 2s infinite;
+      transform-box: fill-box;
     }
 
     #eyelid-left,


### PR DESCRIPTION
Night-mode animation broke in FF. (`transform: translate()` seems to calculate _%_ differently: check https://developer.mozilla.org/en/docs/Web/SVG/Attribute/transform) -> use `transform-box: fill-box;`
