### PR TITLE
Add region to long app name

### DIFF
--- a/library/Denkmal/layout/default/resource/manifest.json.smarty
+++ b/library/Denkmal/layout/default/resource/manifest.json.smarty
@@ -1,5 +1,6 @@
 {
-	"name": "{$render->getSite()->getName()}",
+	"name": "{$render->getSite()->getName()}{if $render->getSite()->hasRegion()} {$render->getSite()->getRegion()->getName()}{/if}",
+	"short_name": "{$render->getSite()->getName()}",
 	"display": "standalone",
 	"start_url": "{$render->getUrl('/')}",
 	"gcm_sender_id": "{$render->getSite()->getPushClientConfiguration()->getGcmSenderId()}",


### PR DESCRIPTION
@christopheschwyzer wdyt?
This way the long name (with region) will be used when showing the dialog, but the short name will be used for the label on the homescreen.