### PR TITLE
Add functions to retrieve event-category by label

### DIFF
--- a/library/Denkmal/library/Denkmal/Model/EventCategory.php
+++ b/library/Denkmal/library/Denkmal/Model/EventCategory.php
@@ -114,6 +114,37 @@ class Denkmal_Model_EventCategory extends CM_Model_Abstract {
         return $eventCategory;
     }
 
+    /**
+     * @param string $label
+     * @return static|null
+     */
+    public static function findByLabel($label) {
+        /** @var CM_Model_StorageAdapter_FindableInterface $persistence */
+        $persistence = self::_getStorageAdapter(self:: getPersistenceClass());
+        $type = self::getTypeStatic();
+        $result = $persistence->findByData($type, ['label' => $label]);
+        $id = $result['id'];
+        if (!$id) {
+            return null;
+        }
+        return new static($id);
+    }
+
+    /**
+     * @param string $label
+     * @return Denkmal_Model_EventCategory
+     * @throws CM_Exception_Invalid
+     */
+    public static function getByLabel($label) {
+        $category = self::findByLabel($label);
+        if (null === $category) {
+            throw new CM_Exception_Invalid('Cannot find event-category by label', null, [
+                'label' => $label,
+            ]);
+        }
+        return $category;
+    }
+
     public static function getPersistenceClass() {
         return 'CM_Model_StorageAdapter_Database';
     }

--- a/tests/library/Denkmal/Model/EventCategoryTest.php
+++ b/tests/library/Denkmal/Model/EventCategoryTest.php
@@ -41,4 +41,11 @@ class Denkmal_Model_EventCategoryTest extends CMTest_TestCase {
         $this->assertSame([], $category->getGenreList());
     }
 
+    public function testFindByLabel() {
+        $category = Denkmal_Model_EventCategory::create('cat-1', new CM_Color_RGB(255, 0, 0), ['foo']);
+
+        $this->assertEquals($category, Denkmal_Model_EventCategory::findByLabel('cat-1'));
+        $this->assertNull(Denkmal_Model_EventCategory::findByLabel('something-else'));
+    }
+
 }


### PR DESCRIPTION
So we can retrieve event categories and change their color:
```php
Denkmal_Model_EventCategory::getByLabel('blues')->setColor(CM_Color_RGB::fromHexString('00FF00'));
```